### PR TITLE
Rename Event's event_type to type.

### DIFF
--- a/sdl.odin
+++ b/sdl.odin
@@ -1776,7 +1776,7 @@ Haptic_Custom :: struct {
 }
 
 Event :: struct #raw_union {
-	event_type: Event_Type,
+	type: Event_Type,
 	common: Common_Event,
 	window: Window_Event,
 	key: Keyboard_Event,
@@ -1806,12 +1806,12 @@ Event :: struct #raw_union {
 }
 
 Common_Event :: struct {
-	event_type: Event_Type,
+	type: Event_Type,
 	timestamp: u32,
 }
 
 Window_Event :: struct {
-	event_type: Event_Type,
+	type: Event_Type,
 	timestamp: u32,
 	window_id: u32,
 	event: Window_Event_ID,
@@ -1823,7 +1823,7 @@ Window_Event :: struct {
 }
 
 Keyboard_Event :: struct {
-	event_type: Event_Type,
+	type: Event_Type,
 	timestamp: u32,
 	window_id: u32,
 	state: u8,
@@ -1835,7 +1835,7 @@ Keyboard_Event :: struct {
 
 TEXT_EDITING_EVENT_TEXT_SIZE :: 32;
 Text_Editing_Event :: struct {
-	event_type: Event_Type,
+	type: Event_Type,
 	timestamp: u32,
 	window_id: u32,
 	text: [TEXT_EDITING_EVENT_TEXT_SIZE]u8,
@@ -1846,14 +1846,14 @@ Text_Editing_Event :: struct {
 
 TEXT_INPUT_EVENT_TEXT_SIZE :: 32;
 Text_Input_Event :: struct {
-	event_type: Event_Type,
+	type: Event_Type,
 	timestamp: u32,
 	window_id: u32,
 	text: [TEXT_INPUT_EVENT_TEXT_SIZE]u8,
 }
 
 Mouse_Motion_Event :: struct {
-	event_type: Event_Type,
+	type: Event_Type,
 	timestamp: u32,
 	window_id: u32,
 	which: u32,
@@ -1865,7 +1865,7 @@ Mouse_Motion_Event :: struct {
 }
 
 Mouse_Button_Event :: struct {
-	event_type: Event_Type,
+	type: Event_Type,
 	timestamp: u32,
 	window_id: u32,
 	which: u32,
@@ -1878,7 +1878,7 @@ Mouse_Button_Event :: struct {
 }
 
 Mouse_Wheel_Event :: struct {
-	event_type: Event_Type,
+	type: Event_Type,
 	timestamp: u32,
 	window_id: u32,
 	which: u32,
@@ -1888,7 +1888,7 @@ Mouse_Wheel_Event :: struct {
 }
 
 Joy_Axis_Event :: struct {
-	event_type: Event_Type,
+	type: Event_Type,
 	timestamp: u32,
 	which: i32,
 	axis: u8,
@@ -1900,7 +1900,7 @@ Joy_Axis_Event :: struct {
 }
 
 Joy_Ball_Event :: struct {
-	event_type: Event_Type,
+	type: Event_Type,
 	timestamp: u32,
 	which: i32,
 	ball: u8,
@@ -1912,7 +1912,7 @@ Joy_Ball_Event :: struct {
 }
 
 Joy_Hat_Event :: struct {
-	event_type: Event_Type,
+	type: Event_Type,
 	timestamp: u32,
 	which: i32,
 	hat: u8,
@@ -1922,7 +1922,7 @@ Joy_Hat_Event :: struct {
 }
 
 Joy_Button_Event :: struct {
-	event_type: Event_Type,
+	type: Event_Type,
 	timestamp: u32,
 	which: i32,
 	button: u8,
@@ -1932,13 +1932,13 @@ Joy_Button_Event :: struct {
 }
 
 Joy_Device_Event :: struct {
-	event_type: Event_Type,
+	type: Event_Type,
 	timestamp: u32,
 	which: i32,
 }
 
 Controller_Axis_Event :: struct {
-	event_type: Event_Type,
+	type: Event_Type,
 	timestamp: u32,
 	which: i32,
 	axis: u8,
@@ -1950,7 +1950,7 @@ Controller_Axis_Event :: struct {
 }
 
 Controller_Button_Event :: struct {
-	event_type: Event_Type,
+	type: Event_Type,
 	timestamp: u32,
 	which: i32,
 	button: u8,
@@ -1960,13 +1960,13 @@ Controller_Button_Event :: struct {
 }
 
 Controller_Device_Event :: struct {
-	event_type: Event_Type,
+	type: Event_Type,
 	timestamp: u32,
 	which: i32,
 }
 
 Audio_Device_Event :: struct {
-	event_type: Event_Type,
+	type: Event_Type,
 	timestamp: u32,
 	which: u32,
 	iscapture: u8,
@@ -1976,7 +1976,7 @@ Audio_Device_Event :: struct {
 }
 
 Touch_Finger_Event :: struct {
-	event_type: Event_Type,
+	type: Event_Type,
 	timestamp: u32,
 	touch_id: i64,
 	finger_id: i64,
@@ -1988,7 +1988,7 @@ Touch_Finger_Event :: struct {
 }
 
 Multi_Gesture_Event :: struct {
-	event_type: Event_Type,
+	type: Event_Type,
 	timestamp: u32,
 	touch_id: i64,
 	d_theta: f32,
@@ -2000,7 +2000,7 @@ Multi_Gesture_Event :: struct {
 }
 
 Dollar_Gesture_Event :: struct {
-	event_type: Event_Type,
+	type: Event_Type,
 	timestamp: u32,
 	touch_id: i64,
 	gesture_id: i64,
@@ -2011,24 +2011,24 @@ Dollar_Gesture_Event :: struct {
 }
 
 Drop_Event :: struct {
-	event_type: Event_Type,
+	type: Event_Type,
 	timestamp: u32,
 	file: cstring,
 	window_id: u32,
 }
 
 Quit_Event :: struct {
-	event_type: Event_Type,
+	type: Event_Type,
 	timestamp: u32,
 }
 
 OS_Event :: struct {
-	event_type: Event_Type,
+	type: Event_Type,
 	timestamp: u32,
 }
 
 User_Event :: struct {
-	event_type: Event_Type,
+	type: Event_Type,
 	timestamp: u32,
 	window_id: u32,
 	code: i32,
@@ -2037,7 +2037,7 @@ User_Event :: struct {
 }
 
 Sys_Wm_Event :: struct {
-	event_type: Event_Type,
+	type: Event_Type,
 	timestamp: u32,
 	msg: ^Sys_Wm_Msg,
 }


### PR DESCRIPTION
Now that `type` isn't a keyword in Odin, we can change the `event_type` fields to `type` and stay consistent with the SDL source.