### PR TITLE
Add binding to SDL_GetError in SDL2_Image

### DIFF
--- a/image/sdl_image.odin
+++ b/image/sdl_image.odin
@@ -8,7 +8,7 @@ when os.OS == "linux" do foreign import lib "system:SDL2_image";
 
 @(default_calling_convention="c")
 foreign lib {
-	@(link_name="IMG_Init") init :: proc(flags: Init_Flags) -> i32																				---;
+	@(link_name="IMG_Init") init :: proc(flags: Init_Flags) -> Init_Flags																				---;
 	@(link_name="IMG_Linked_Version") linked_version :: proc() -> ^sdl.Version																				---;
 	@(link_name="IMG_Load") load :: proc(file: cstring) -> ^sdl.Surface																		---;
 	@(link_name="IMG_LoadBMP_RW") load_bmp_rw :: proc(src: ^sdl.Rw_Ops) -> ^sdl.Surface																---;

--- a/image/sdl_image.odin
+++ b/image/sdl_image.odin
@@ -49,6 +49,7 @@ foreign lib {
 	@(link_name="IMG_isXCF") is_xcf :: proc(src: ^sdl.Rw_Ops) -> i32																			---;
 	@(link_name="IMG_isXPM") is_xpm :: proc(src: ^sdl.Rw_Ops) -> i32																			---;
 	@(link_name="IMG_isXV") is_xv :: proc(src: ^sdl.Rw_Ops) -> i32																			---;
+    @(link_name="SDL_GetError") get_error :: proc() -> cstring ---;
 }
 
 Init_Flags :: enum i32

--- a/sdl.odin
+++ b/sdl.odin
@@ -325,20 +325,20 @@ foreign lib {
 	@(link_name="SDL_LockSurface") lock_surface :: proc(surface: ^Surface) -> i32																																---;
 	@(link_name="SDL_LockTexture") lock_texture :: proc(texture: ^Texture, rect: ^Rect, pixels: ^rawptr, pitch: ^i32) -> i32																					---;
 	@(link_name="SDL_Log") log :: proc(fmt: ..cstring)																																			---;
-	@(link_name="SDL_LogCritical") log_critical :: proc(category: i32, fmt: ..cstring)																																---;
-	@(link_name="SDL_LogDebug") log_debug :: proc(category: i32, fmt: ..cstring)																																---;
-	@(link_name="SDL_LogError") log_error :: proc(category: i32, fmt: ..cstring)																																---;
+	@(link_name="SDL_LogCritical") log_critical :: proc(category: Log_Category, fmt: ..cstring)																																---;
+	@(link_name="SDL_LogDebug") log_debug :: proc(category: Log_Category, fmt: ..cstring)																																---;
+	@(link_name="SDL_LogError") log_error :: proc(category: Log_Category, fmt: ..cstring)																																---;
 	@(link_name="SDL_LogGetOutputFunction") log_get_output_function :: proc(callback: ^Log_Output_Function, userdata: ^rawptr)																										---;
-	@(link_name="SDL_LogGetPriority") log_get_priority :: proc(category: i32) -> Log_Priority																															---;
-	@(link_name="SDL_LogInfo") log_info :: proc(category: i32, fmt: ..cstring)																																---;
-	@(link_name="SDL_LogMessage") log_message :: proc(category: i32, priority: Log_Priority, fmt: ..cstring)																										---;
-	@(link_name="SDL_LogMessageV") log_message_v :: proc(category: i32, priority: Log_Priority, fmt: cstring, va_list: cstring)																							---;
+	@(link_name="SDL_LogGetPriority") log_get_priority :: proc(category: Log_Category) -> Log_Priority																															---;
+	@(link_name="SDL_LogInfo") log_info :: proc(category: Log_Category, fmt: ..cstring)																																---;
+	@(link_name="SDL_LogMessage") log_message :: proc(category: Log_Category, priority: Log_Priority, fmt: ..cstring)																										---;
+	@(link_name="SDL_LogMessageV") log_message_v :: proc(category: Log_Category, priority: Log_Priority, fmt: cstring, va_list: cstring)																							---;
 	@(link_name="SDL_LogResetPriorities") log_reset_priorities :: proc()																																						---;
 	@(link_name="SDL_LogSetAllPriority") log_set_all_priority :: proc(priority: Log_Priority)																																	---;
 	@(link_name="SDL_LogSetOutputFunction") log_set_output_function :: proc(callback: Log_Output_Function, userdata: rawptr)																										---;
-	@(link_name="SDL_LogSetPriority") log_set_priority :: proc(category: i32, priority: Log_Priority)																													---;
-	@(link_name="SDL_LogVerbose") log_verbose :: proc(category: i32, fmt: ..cstring)																																---;
-	@(link_name="SDL_LogWarn") log_warn :: proc(category: i32, fmt: ..cstring)																																---;
+	@(link_name="SDL_LogSetPriority") log_set_priority :: proc(category: Log_Category, priority: Log_Priority)																													---;
+	@(link_name="SDL_LogVerbose") log_verbose :: proc(category: Log_Category, fmt: ..cstring)																																---;
+	@(link_name="SDL_LogWarn") log_warn :: proc(category: Log_Category, fmt: ..cstring)																																---;
 	@(link_name="SDL_LowerBlit") lower_blit :: proc(src: ^Surface, srcrect: ^Rect, dst: ^Surface, dstrect: ^Rect) -> i32																					---;
 	@(link_name="SDL_LowerBlitScaled") lower_blit_scaled :: proc(src: ^Surface, srcrect: ^Rect, dst: ^Surface, dstrect: ^Rect) -> i32																					---;
 	@(link_name="SDL_MapRGB") map_rgb :: proc(format: ^Pixel_Format, r, g, b: u8) -> u32																												---;
@@ -723,6 +723,20 @@ Power_State :: enum i32 {
 	Charged
 }
 
+Log_Category :: enum i32 {
+    Application,
+    Error,
+    Assert,
+    System,
+    Audio,
+    Video,
+    Render,
+    Input,
+    Test,
+
+    Custom = 19
+}
+
 Log_Priority :: enum i32 {
 	Verbose = 1,
 	Debug,
@@ -732,7 +746,6 @@ Log_Priority :: enum i32 {
 	Critical,
 	Num_Log_Priorities
 }
-
 
 // Input stuff
 
@@ -1459,7 +1472,7 @@ Audio_Filter :: proc "c" (cvt: ^Audio_Cvt, format: Audio_Format);
 Thread_Function :: proc "c" (data: rawptr) -> i32;
 Hit_Test :: proc "c" (window: ^Window, area: ^Point, data: rawptr) -> Hit_Test_Result;
 Windows_Message_Hook :: proc "c" (userdata: rawptr, hwnd: rawptr, message: u32, wparam: u64, lparam: i64);
-Log_Output_Function :: proc "c" (userdata: rawptr, category: i32, priority: Log_Priority, message: cstring);
+Log_Output_Function :: proc "c" (userdata: rawptr, category: Log_Category, priority: Log_Priority, message: cstring);
 
 // Thanks gingerBill for this one!
 Game_Controller_Button_Bind :: struct {


### PR DESCRIPTION
The first commit emulates the macro in SDL_Image.h for IMG_GetError.

The second commit returns an enum from SDL_Init binding instead of an i32. The original C function has it returning an int, when I think it should have been the enum all along. Maybe we don't want to have this implicitly cast the int on the proc call? It will need to be casted anyway, so this would just be a convenience.

The third commit allows for using the logging categories that were missing in the bindings.